### PR TITLE
fix: 修复 Windows 平台 SIGTERM 信号不支持的问题

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -764,11 +764,14 @@ Deno.addSignalListener("SIGINT", async () => {
   Deno.exit(0);
 });
 
-Deno.addSignalListener("SIGTERM", async () => {
-  info("Startup", "收到 SIGTERM, 关闭服务...");
-  await closeLogger();
-  Deno.exit(0);
-});
+// Windows only supports SIGINT/SIGBREAK, not SIGTERM
+if (Deno.build.os !== "windows") {
+  Deno.addSignalListener("SIGTERM", async () => {
+    info("Startup", "收到 SIGTERM, 关闭服务...");
+    await closeLogger();
+    Deno.exit(0);
+  });
+}
 
 Deno.serve({ port: PORT }, (req: Request) => {
   if (req.method === "OPTIONS") {


### PR DESCRIPTION
## 关联 Issue

Closes #2

## 变更内容

修复 Windows 平台无法启动服务的问题。

### 问题原因

Windows 系统不支持 `SIGTERM` 信号，只支持：
- `SIGINT` (Ctrl+C)
- `SIGBREAK` (Ctrl+Break)  
- `SIGHUP` (控制台关闭)

直接运行 `deno task start` 会报错：
```
TypeError: Windows only supports ctrl-c (SIGINT), ctrl-break (SIGBREAK), 
and ctrl-close (SIGUP), but got SIGTERM
```

### 解决方案

添加平台判断，仅在非 Windows 系统上注册 SIGTERM 信号监听器：

```typescript
// Windows only supports SIGINT/SIGBREAK, not SIGTERM
if (Deno.build.os !== "windows") {
  Deno.addSignalListener("SIGTERM", async () => {
    info("Startup", "收到 SIGTERM, 关闭服务...");
    await closeLogger();
    Deno.exit(0);
  });
}
```

### 影响范围

- ✅ Windows 用户可以正常启动服务
- ✅ Linux/macOS 用户不受影响，仍支持 SIGTERM 优雅关闭
- ✅ 所有平台仍支持 Ctrl+C (SIGINT) 优雅关闭

## 测试结果

| 平台 | 启动 | Ctrl+C 关闭 | SIGTERM 关闭 |
|------|------|-------------|--------------|
| Windows 11 | ✅ | ✅ | N/A |
| Linux (预期) | ✅ | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)