### PR TITLE
feat: 新增 Pollinations.ai 渠道支持，支持文生图与图生图

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ Thumbs.db
 # Rooroo 工作目录
 .rooroo/
 
+# ampcode 工作目录
+.amp/
+
 # Docker Compose 覆盖配置（本地使用）
 docker-compose.override.yml
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## 特性
 
 - **智能路由** - 根据 API Key 格式自动识别并分发到对应渠道
-- **多渠道支持** - 火山引擎、Gitee (模力方舟)、ModelScope (魔搭)、Hugging Face
+- **多渠道支持** - 火山引擎、Gitee (模力方舟)、ModelScope (魔搭)、Hugging Face、Pollinations
 - **OpenAI 兼容** - 完全兼容 `/v1/chat/completions` 接口格式
 - **流式响应** - 支持 SSE 流式输出
 - **文生图 & 图生图** - 支持纯文字生成图片，也支持上传参考图片进行图片编辑
@@ -34,19 +34,19 @@
 │  │ hf_*        │ ms-*            │ UUID 格式            │    │
 │  │ → HuggingFace│ → ModelScope   │ → VolcEngine        │    │
 │  │             │                 │                     │    │
-│  │             │ 30-60位字母数字  │                     │    │
-│  │             │ → Gitee         │                     │    │
+│  │ pk_* / sk_* │ 30-60位字母数字  │                     │    │
+│  │ → Pollinations│ → Gitee       │                     │    │
 │  └─────────────┴─────────────────┴─────────────────────┘    │
 └─────────────────────┬───────────────────────────────────────┘
                        │
-           ┌───────────┼───────────┬───────────┐
-           ▼           ▼           ▼           ▼
-     ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
-     │VolcEngine│ │  Gitee   │ │ModelScope│ │HuggingFace│
-     │ (火山)   │ │(模力方舟)│ │  (魔搭)  │ │ (抱抱脸) │
-     └──────────┘ └──────────┘ └──────────┘ └──────────┘
-           │           │           │           │
-           └───────────┴───────────┴───────────┘
+           ┌───────────┼───────────┬───────────┬───────────┐
+           ▼           ▼           ▼           ▼           ▼
+     ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+     │VolcEngine│ │  Gitee   │ │ModelScope│ │HuggingFace│ │Pollinations│
+     │ (火山)   │ │(模力方舟)│ │  (魔搭)  │ │ (抱抱脸) │ │          │
+     └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘
+           │           │           │           │           │
+           └───────────┴───────────┴───────────┴───────────┘
                        │
                        ▼
               ┌─────────────────┐
@@ -69,6 +69,8 @@
 | **ModelScope** | 图生图 | JSON (URL 数组)¹ | URL (异步轮询) | Base64 |
 | **HuggingFace** | 文生图 | JSON (Gradio API) | URL (SSE) | Base64 |
 | **HuggingFace** | 图生图 | Blob 上传 + JSON | URL (SSE) | Base64 |
+| **Pollinations** | 文生图 | GET (URL 参数) | 图片二进制 | Base64 |
+| **Pollinations** | 图生图 | JSON (OpenAI 兼容) | URL / Base64 | Base64 |
 
 > ¹ 如果输入是 Base64 图片，会先自动上传到图床转换为 URL 再发送给 API
 
@@ -128,6 +130,7 @@ export const VolcEngineConfig = { ... };
 export const GiteeConfig = { ... };
 export const ModelScopeConfig = { ... };
 export const HuggingFaceConfig = { ... };
+export const PollinationsConfig = { ... };
 ```
 
 ### 修改默认模型
@@ -228,6 +231,50 @@ export const HuggingFaceConfig = {
 };
 ```
 
+### 配置 Pollinations 参数
+
+Pollinations 支持多种特有参数，可以在 `config.ts` 中配置：
+
+```typescript
+export const PollinationsConfig = {
+  // 基础配置
+  defaultModel: "flux",              // 文生图默认模型
+  defaultEditModel: "gptimage",      // 图生图默认模型
+  defaultSize: "1024x1024",          // 文生图默认尺寸
+  defaultEditSize: "1024x1024",      // 图生图默认尺寸
+
+  // 图像生成参数
+  seed: -1,                          // 随机种子：-1 表示每次随机
+  quality: "hd",                     // 质量：low/medium/high/hd
+  transparent: false,                // 透明背景
+  guidanceScale: undefined,          // 提示词遵循强度(1-20)，不填则使用服务端默认
+  
+  // 特有参数
+  enhance: true,                     // 让 AI 优化 prompt 以获得更好效果
+  negativePrompt: "",                // 负面提示词（避免生成的内容）
+  private: true,                     // 隐藏图片，不显示在公共 feed
+  nologo: true,                      // 移除 Pollinations 水印
+  nofeed: false,                     // 不添加到公共 feed
+  safe: false,                       // 启用安全内容过滤器
+  // ...
+};
+```
+
+**参数说明：**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `seed` | number | -1 | 随机种子，-1 表示每次随机，固定值可复现结果 |
+| `quality` | string | "hd" | 图像质量：low/medium/high/hd |
+| `transparent` | boolean | false | 生成透明背景图片 |
+| `guidanceScale` | number | undefined | 提示词遵循强度 (1-20)，不填使用服务端默认 |
+| `enhance` | boolean | true | 让 AI 自动优化你的 prompt 以获得更好的生成效果 |
+| `negativePrompt` | string | "" | 负面提示词，指定要避免生成的内容（如 "blurry, low quality"） |
+| `private` | boolean | true | 将生成的图片设为私密，不显示在公共 feed 中 |
+| `nologo` | boolean | true | 移除 Pollinations 水印（需要有效的 API Key） |
+| `nofeed` | boolean | false | 不将图片添加到公共 feed |
+| `safe` | boolean | false | 启用安全内容过滤器，过滤不当内容 |
+
 ### 修改超时时间
 
 ```typescript
@@ -245,6 +292,7 @@ export const API_TIMEOUT_MS = 300000;
 | Gitee | 30-60位字母数字 | `abc123def456...` |
 | ModelScope | `ms-` 开头 | `ms-xxxxxxxxxx` |
 | Hugging Face | `hf_` 开头 | `hf_xxxxxxxxxx` |
+| Pollinations | `pk_` 或 `sk_` 开头 | `pk_3Ff4YHCp8TkauKXq` 或 `sk_zzqmqZp3Jex...` |
 
 系统根据 API Key 格式自动识别渠道，无需手动指定。
 
@@ -300,6 +348,27 @@ export const API_TIMEOUT_MS = 300000;
 |------|------|------|
 | `z-image-turbo` | 文生图 | 默认模型 |
 | `Qwen-Image-Edit-2511` | 图生图 | 图片编辑模型 |
+
+### Pollinations 模型
+
+| 模型 | 类型 | 说明 |
+|------|------|------|
+| `flux` | 文生图 | 默认模型，Flux Schnell |
+| `turbo` | 文生图 | SDXL Turbo 单步实时 |
+| `zimage` | 文生图 | Z-Image Turbo + 2x放大 |
+| `kontext` | 文生图/图生图 | FLUX.1 Kontext 编辑 |
+| `nanobanana` | 文生图/图生图 | Gemini 2.5 Flash Image |
+| `nanobanana-pro` | 文生图/图生图 | Gemini 3 Pro Image (4K) |
+| `seedream` | 文生图/图生图 | ByteDance Seedream 4.0 |
+| `seedream-pro` | 文生图/图生图 | ByteDance Seedream 4.5 (4K) |
+| `gptimage` | 文生图/图生图 | GPT Image Mini（图生图默认） |
+| `gptimage-large` | 文生图/图生图 | GPT Image 1.5 高级版 |
+
+> **Pollinations 密钥说明：**
+> - `pk_` 开头：公共密钥，有速率限制 (1 pollen/小时/IP)
+> - `sk_` 开头：私密密钥，无速率限制，适合服务端使用
+>
+> **尺寸说明：** 部分模型对尺寸有限制，如 `gptimage-large` 可能会自动调整到最接近的支持尺寸
 
 ## 配置
 

--- a/config.ts
+++ b/config.ts
@@ -14,7 +14,7 @@ export const ImageBedConfig = {
 };
 
 // ================= 渠道配置 =================
-// 支持：火山引擎 (VolcEngine/豆包)、Gitee (模力方舟)、ModelScope (魔搭)、Hugging Face
+// 支持：火山引擎 (VolcEngine/豆包)、Gitee (模力方舟)、ModelScope (魔搭)、Hugging Face、Pollinations
 
 // 渠道配置接口
 export interface ProviderConfig {
@@ -160,6 +160,71 @@ export const HuggingFaceConfig: HuggingFaceProviderConfigExtended = {
   editModels: [
     "Qwen-Image-Edit-2511",
   ],
+};
+
+// Pollinations 配置接口
+export interface PollinationsProviderConfig {
+  apiUrl: string;                    // API 网关地址
+  imageEndpoint: string;             // 图片生成端点
+  defaultModel: string;              // 文生图默认模型
+  defaultEditModel: string;          // 图生图默认模型
+  defaultSize: string;               // 文生图默认尺寸
+  defaultEditSize: string;           // 图生图默认尺寸
+  supportedModels: string[];         // 文生图支持的模型
+  editModels: string[];              // 图生图支持的模型
+  // Pollinations 特有参数
+  seed?: number;                     // 随机种子：-1 表示每次随机（与官方文档一致）
+  quality?: "low" | "medium" | "high" | "hd"; // 质量档位
+  transparent: boolean;              // 透明背景
+  guidanceScale?: number;            // 提示词遵循强度（1-20），不填则由服务端默认
+  enhance: boolean;                  // 让 AI 优化 prompt 以获得更好效果
+  negativePrompt: string;            // 负面提示词，避免生成的内容
+  private: boolean;                  // 隐藏图片，不显示在公共 feed
+  nologo: boolean;                   // 移除 Pollinations 水印
+  nofeed: boolean;                   // 不添加到公共 feed
+  safe: boolean;                     // 启用安全内容过滤器
+}
+
+// Pollinations 配置 (支持 pk_ 公共密钥和 sk_ 私密密钥)
+export const PollinationsConfig: PollinationsProviderConfig = {
+  apiUrl: "https://gen.pollinations.ai",
+  imageEndpoint: "/image",
+  defaultModel: "flux",
+  defaultEditModel: "gptimage",
+  defaultSize: "1024x1024",          // 文生图默认尺寸
+  defaultEditSize: "1024x1024",      // 图生图默认尺寸
+  supportedModels: [
+    "flux",           // Flux Schnell - 快速高质量
+    "turbo",          // SDXL Turbo - 单步实时
+    "zimage",         // Z-Image Turbo
+    "kontext",        // FLUX.1 Kontext - 支持图生图
+    "nanobanana",     // Gemini 2.5 Flash Image
+    "nanobanana-pro", // Gemini 3 Pro Image (4K)
+    "seedream",       // Seedream 4.0
+    "seedream-pro",   // Seedream 4.5 Pro (4K)
+    "gptimage",       // GPT Image Mini
+    "gptimage-large", // GPT Image 1.5
+  ],
+  editModels: [
+    "gptimage",       // GPT Image Mini - 图生图首选
+    "gptimage-large", // GPT Image 1.5
+    "kontext",        // FLUX.1 Kontext
+    "nanobanana",     // Gemini 2.5 Flash Image
+    "nanobanana-pro", // Gemini 3 Pro Image
+    "seedream",       // Seedream 支持图片输入
+    "seedream-pro",
+  ],
+  // Pollinations 特有参数默认值
+  seed: -1,                          // -1 表示每次随机
+  quality: "hd",                // 官方文档默认 medium，有low|medium|high|hd选项
+  transparent: false,
+  guidanceScale: undefined,
+  enhance: true,                     // 默认优化 prompt
+  negativePrompt: "",                // 默认无负面提示词（API 默认为 "worst quality, blurry"）
+  private: true,                     // 默认私密
+  nologo: true,                      // 默认移除水印
+  nofeed: false,                     // 默认添加到 feed
+  safe: false,                       // 默认不启用安全过滤
 };
 
 // 统一超时时间：300秒（适用于所有渠道的 API 请求，给生图留足时间）

--- a/main.ts
+++ b/main.ts
@@ -12,10 +12,10 @@ import {
 } from "./logger.ts";
 import {
   VolcEngineConfig, GiteeConfig, ModelScopeConfig, HuggingFaceConfig,
-  ImageBedConfig, API_TIMEOUT_MS, PORT,
+  PollinationsConfig, ImageBedConfig, API_TIMEOUT_MS, PORT,
 } from "./config.ts";
 
-type Provider = "VolcEngine" | "Gitee" | "ModelScope" | "HuggingFace" | "Unknown";
+type Provider = "VolcEngine" | "Gitee" | "ModelScope" | "HuggingFace" | "Pollinations" | "Unknown";
 
 interface TextContentItem {
   type: "text";
@@ -44,6 +44,13 @@ interface ChatRequest {
 
 function detectProvider(apiKey: string): Provider {
   if (!apiKey) return "Unknown";
+
+  // Pollinations - pk_ 或 sk_ 开头
+  if (apiKey.startsWith("pk_") || apiKey.startsWith("sk_")) {
+    logProviderRouting("Pollinations", apiKey.substring(0, 3));
+    return "Pollinations";
+  }
+
   if (apiKey.startsWith("hf_")) {
     logProviderRouting("HuggingFace", apiKey.substring(0, 4));
     return "HuggingFace";
@@ -152,7 +159,8 @@ async function fetchWithTimeout(
   const isOfficialApi = url.includes("volces.com") ||
                         url.includes("gitee.com") ||
                         url.includes("modelscope.cn") ||
-                        url.includes("hf.space");
+                        url.includes("hf.space") ||
+                        url.includes("pollinations.ai");
 
   if (url.startsWith("http") && !isOfficialApi) {
     if (!isSafeUrl(url)) {
@@ -1310,6 +1318,206 @@ function extractImageUrlFromSSE(sseStream: string, baseUrl?: string): string | n
   return null;
 }
 
+/** Pollinations 文生图 - 使用简单的 GET 端点 */
+async function pollinationsGenerateImage(
+  apiKey: string,
+  prompt: string,
+  reqBody: ChatRequest
+): Promise<string> {
+  const model = reqBody.model || PollinationsConfig.defaultModel;
+  const size = reqBody.size || PollinationsConfig.defaultSize;
+  const [width, height] = size.split("x").map(Number);
+  
+  const encodedPrompt = encodeURIComponent(prompt);
+  const url = `${PollinationsConfig.apiUrl}${PollinationsConfig.imageEndpoint}/${encodedPrompt}`;
+  
+  // 构建请求参数，使用配置中的特有参数
+  const params = new URLSearchParams({
+    model,
+    width: String(width || 1024),
+    height: String(height || 1024),
+  });
+
+  // 添加 Pollinations 参数（仅使用全局配置）
+  // seed：按配置原样透传（-1 也直接传给服务端）；未配置则不传
+  if (PollinationsConfig.seed !== undefined) params.set("seed", String(PollinationsConfig.seed));
+
+  if (PollinationsConfig.quality !== undefined) params.set("quality", String(PollinationsConfig.quality));
+  if (PollinationsConfig.transparent) params.set("transparent", "true");
+  if (PollinationsConfig.guidanceScale !== undefined) params.set("guidance_scale", String(PollinationsConfig.guidanceScale));
+
+  if (PollinationsConfig.nologo) params.set("nologo", "true");
+  if (PollinationsConfig.enhance) params.set("enhance", "true");
+  if (PollinationsConfig.negativePrompt) params.set("negative_prompt", PollinationsConfig.negativePrompt);
+  if (PollinationsConfig.private) params.set("private", "true");
+  if (PollinationsConfig.nofeed) params.set("nofeed", "true");
+  if (PollinationsConfig.safe) params.set("safe", "true");
+  
+  const fullUrl = `${url}?${params.toString()}`;
+  
+  info("Pollinations", `请求 URL: ${fullUrl.substring(0, 100)}...`);
+  
+  const response = await fetchWithTimeout(fullUrl, {
+    method: "GET",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+    },
+  });
+  
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Pollinations API 错误 (${response.status}): ${errorText}`);
+  }
+  
+  // GET 端点直接返回图片二进制，转换为 Base64
+  const arrayBuffer = await response.arrayBuffer();
+  const uint8Array = new Uint8Array(arrayBuffer);
+  
+  let mimeType = detectImageMimeType(uint8Array);
+  if (!mimeType) {
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.startsWith("image/")) {
+      mimeType = contentType.split(";")[0].trim();
+    } else {
+      mimeType = "image/png";
+    }
+  }
+  
+  const base64 = encodeBase64(uint8Array);
+  return `data:${mimeType};base64,${base64}`;
+}
+
+/** Pollinations 图生图 - 使用 GET /image 端点 + image 参数 */
+async function pollinationsImageEdit(
+  apiKey: string,
+  prompt: string,
+  images: string[],
+  reqBody: ChatRequest
+): Promise<string> {
+  // 选择支持图片输入的模型
+  let model = reqBody.model || PollinationsConfig.defaultEditModel;
+  
+  // 如果用户指定的模型不支持图生图，自动切换到默认图生图模型
+  if (!PollinationsConfig.editModels.includes(model)) {
+    info("Pollinations", `模型 ${model} 不支持图生图，切换到 ${PollinationsConfig.defaultEditModel}`);
+    model = PollinationsConfig.defaultEditModel;
+  }
+  
+  const size = reqBody.size || PollinationsConfig.defaultEditSize;
+  const [width, height] = size.split("x").map(Number);
+  
+  // 使用 GET /image 端点，通过 image 参数传递图片 URL
+  // 多张图片用 | 分隔
+  const imageParam = images.join("|");
+  
+  const encodedPrompt = encodeURIComponent(prompt);
+  const url = `${PollinationsConfig.apiUrl}${PollinationsConfig.imageEndpoint}/${encodedPrompt}`;
+  
+  // 构建请求参数
+  const params = new URLSearchParams({
+    model,
+    width: String(width || 1024),
+    height: String(height || 1024),
+    image: imageParam,
+  });
+
+  // 添加 Pollinations 参数
+  if (PollinationsConfig.seed !== undefined) params.set("seed", String(PollinationsConfig.seed));
+  if (PollinationsConfig.quality !== undefined) params.set("quality", String(PollinationsConfig.quality));
+  if (PollinationsConfig.transparent) params.set("transparent", "true");
+  if (PollinationsConfig.guidanceScale !== undefined) params.set("guidance_scale", String(PollinationsConfig.guidanceScale));
+  if (PollinationsConfig.nologo) params.set("nologo", "true");
+  if (PollinationsConfig.enhance) params.set("enhance", "true");
+  if (PollinationsConfig.negativePrompt) params.set("negative_prompt", PollinationsConfig.negativePrompt);
+  if (PollinationsConfig.private) params.set("private", "true");
+  if (PollinationsConfig.nofeed) params.set("nofeed", "true");
+  if (PollinationsConfig.safe) params.set("safe", "true");
+  
+  const fullUrl = `${url}?${params.toString()}`;
+  
+  info("Pollinations", `图生图请求，模型: ${model}, 图片数: ${images.length}`);
+  debug("Pollinations", `请求 URL: ${fullUrl.substring(0, 150)}...`);
+  
+  const response = await fetchWithTimeout(fullUrl, {
+    method: "GET",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+    },
+  });
+  
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Pollinations API 错误 (${response.status}): ${errorText}`);
+  }
+  
+  // GET 端点直接返回图片二进制，转换为 Base64
+  const arrayBuffer = await response.arrayBuffer();
+  const uint8Array = new Uint8Array(arrayBuffer);
+  
+  let mimeType = detectImageMimeType(uint8Array);
+  if (!mimeType) {
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.startsWith("image/")) {
+      mimeType = contentType.split(";")[0].trim();
+    } else {
+      mimeType = "image/png";
+    }
+  }
+  
+  const base64 = encodeBase64(uint8Array);
+  return `data:${mimeType};base64,${base64}`;
+}
+
+/** Pollinations 图片生成 */
+async function handlePollinations(
+  apiKey: string,
+  reqBody: ChatRequest,
+  prompt: string,
+  images: string[],
+  requestId: string
+): Promise<string> {
+  const startTime = Date.now();
+  const hasImages = images.length > 0;
+  const apiType = hasImages ? "image_edit" : "generate_image";
+  logApiCallStart("Pollinations", apiType);
+  
+  logFullPrompt("Pollinations", requestId, prompt);
+  if (images.length > 0) {
+    logInputImages("Pollinations", requestId, images);
+  }
+  
+  const model = reqBody.model || (hasImages ? PollinationsConfig.defaultEditModel : PollinationsConfig.defaultModel);
+  const size = reqBody.size || PollinationsConfig.defaultSize;
+  logImageGenerationStart("Pollinations", requestId, model, size, prompt.length);
+  
+  try {
+    let imageData: string;
+    
+    if (hasImages) {
+      // 图生图：使用 GET /image 端点 + image 参数，直接返回 data URL
+      imageData = await pollinationsImageEdit(apiKey, prompt, images, reqBody);
+    } else {
+      // 文生图：使用 GET 端点，直接返回 data URL
+      imageData = await pollinationsGenerateImage(apiKey, prompt, reqBody);
+    }
+    
+    const result = `![Generated Image](${imageData})`;
+    const duration = Date.now() - startTime;
+    
+    logApiCallEnd("Pollinations", apiType, true, duration);
+    logGeneratedImages("Pollinations", requestId, [{ b64_json: imageData.substring(0, 100) + "..." }]);
+    logImageGenerationComplete("Pollinations", requestId, 1, duration);
+    
+    return result;
+    
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logApiCallEnd("Pollinations", apiType, false, Date.now() - startTime);
+    logImageGenerationFailed("Pollinations", requestId, msg);
+    throw e;
+  }
+}
+
 async function handleChatCompletions(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const requestId = generateRequestId();
@@ -1377,6 +1585,9 @@ async function handleChatCompletions(req: Request): Promise<Response> {
         break;
       case "HuggingFace":
         imageContent = await handleHuggingFace(apiKey, requestBody, prompt, images, requestId);
+        break;
+      case "Pollinations":
+        imageContent = await handlePollinations(apiKey, requestBody, prompt, images, requestId);
         break;
     }
 
@@ -1491,7 +1702,7 @@ if (logLevel && logLevel in LogLevel) {
 const version = await getVersion();
 info("Startup", `🚀 服务启动端口 ${PORT}`);
 info("Startup", `📦 版本: ${version}`);
-info("Startup", "🔧 支持: 火山引擎, Gitee, ModelScope, HuggingFace");
+info("Startup", "🔧 支持: 火山引擎, Gitee, ModelScope, HuggingFace, Pollinations");
 info("Startup", `📁 日志目录: ./data/logs`);
 
 Deno.addSignalListener("SIGINT", async () => {


### PR DESCRIPTION
### 📝 背景与目的

本次更新为 `img-router` 集成了 [Pollinations.ai](https://pollinations.ai/) 图像生成渠道。Pollinations 提供了一系列高质量的开源模型（如 Flux, SDXL Turbo 等），且支持通过 API Key 快速调用。

### 🚀 主要变更

* **智能路由识别**：在 `main.ts` 中新增了 API Key 前缀识别。系统现在可自动识别以 `pk_` (公共密钥) 或 `sk_` (私密密钥) 开头的 Key 并路由至 Pollinations 渠道。
* **文生图 & 图生图支持**：
* 实现了 `pollinationsGenerateImage`：支持基础的文生图功能。
* 实现了 `pollinationsImageEdit`：支持通过 `image` 参数进行图片编辑与参考生图。


* **灵活的参数配置**：在 `config.ts` 中新增了 `PollinationsConfig`，支持配置 `seed`、`quality` (low/hd)、`enhance` (提示词优化)、`nologo` 等特有参数。
* **模型库扩充**：新增了对 `flux`、`turbo`、`gptimage`、`nanobanana` 等多达 10 款模型的适配。
* **文档同步更新**：更新了 `README.md`，添加了 Pollinations 的参数说明、模型列表及密钥使用规范。

### 🛠️ 技术细节

* **接口适配**：采用 Pollinations 的 GET 端点进行图片生成，并将二进制结果转换为 Base64 返回，保持与 OpenAI 接口格式兼容。
* **环境变更**：`.gitignore` 中新增了 `.amp/` 工作目录屏蔽。

### ✅ 测试建议

1. 在配置中填入 Pollinations 的 API Key (`pk_...` 或 `sk_...`)。
2. 发送文生图请求，验证是否能正确生成并返回 Base64 图片。
3. 发送带图片的图生图请求，验证模型是否能正确处理参考图。